### PR TITLE
feat: add board tiles generation, add board options, add two new systems to handle window

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,3 @@
-mod coordinates;
-
 pub use coordinates::Coordinates;
+
+mod coordinates;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,8 @@ use winit::window::Icon;
 
 use crate::components::Coordinates;
 use crate::plugins::BoardPlugin;
-use crate::systems::setup_2d_camera;
+use crate::resources::BoardOptions;
+use crate::systems::{make_window_visible_after_startup, setup_2d_camera, toggle_vsync};
 
 mod components;
 mod plugins;
@@ -41,12 +42,14 @@ fn main() {
                 minimize: true,
             },
             position: WindowPosition::Centered(MonitorSelection::Primary),
+            // This will spawn an invisible window
+            // The window will be made visible in the make_visible() system after 3 frames.
+            // This is useful when you want to avoid the white window that shows up before the GPU is ready to render the app.
+            visible: false,
             ..default()
         }),
         ..default()
     }));
-
-    app.add_plugins(BoardPlugin);
 
     #[cfg(feature = "debug")]
     add_debug_plugins(&mut app);
@@ -54,8 +57,20 @@ fn main() {
     #[cfg(feature = "debug")]
     register_custom_types_for_bevy_inspector_egui(&mut app);
 
+    app.insert_resource(BoardOptions {
+        map_size: (20, 20),
+        mine_count: 40,
+        tile_padding: 3.0,
+        ..default()
+    });
+
+    app.add_plugins(BoardPlugin);
+
     app.add_systems(Startup, set_window_icon);
     app.add_systems(Startup, setup_2d_camera);
+    app.add_systems(Update, make_window_visible_after_startup);
+    app.add_systems(Update, toggle_vsync);
+
     app.run();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use bevy::winit::WinitWindows;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use winit::window::Icon;
 
+#[cfg(feature = "debug")]
 use crate::components::Coordinates;
 use crate::plugins::BoardPlugin;
 use crate::resources::BoardOptions;

--- a/src/plugins/board.rs
+++ b/src/plugins/board.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 
-use crate::resources::TileMap;
+use crate::components::Coordinates;
+use crate::resources::{BoardOptions, BoardPosition, TileMap, TileSize};
 
 pub struct BoardPlugin;
 
@@ -12,11 +13,106 @@ impl Plugin for BoardPlugin {
 }
 
 impl BoardPlugin {
-    pub fn create_board() {
-        let mut tile_map = TileMap::new_empty(20, 20);
-        tile_map.set_mines(40);
+    pub fn create_board(
+        mut commands: Commands,
+        board_options: Option<Res<BoardOptions>>,
+        windows: Query<&Window>,
+    ) {
+        let window = windows.single();
+
+        let options = match board_options {
+            Some(o) => *o,
+            None => BoardOptions::default(),
+        };
+
+        let (map_size_x, map_size_y) = options.map_size;
+        let mut tile_map = TileMap::new_empty(map_size_x, map_size_y);
+        tile_map.set_mines(options.mine_count);
 
         #[cfg(feature = "debug")]
         info!("{}", tile_map.console_output());
+
+        let tile_size = match options.tile_size {
+            TileSize::Fixed(size) => size,
+            TileSize::WindowAdaptive { min, max } => {
+                Self::adaptive_tile_size(window, (min, max), (tile_map.width(), tile_map.height()))
+            }
+        };
+
+        let board_size = Vec2::new(
+            tile_map.width() as f32 * tile_size,
+            tile_map.height() as f32 * tile_size,
+        );
+        info!("Board size: {}", board_size);
+
+        let board_position = match options.position {
+            BoardPosition::Centered { offset } => {
+                Vec3::new(-(board_size.x / 2f32), -(board_size.y / 2f32), 0f32) + offset
+            }
+            BoardPosition::CustomPosition(pos) => pos,
+        };
+
+        info!("Spawning board");
+        commands
+            .spawn((
+                Name::new("Board"),
+                SpatialBundle {
+                    transform: Transform::from_translation(board_position),
+                    ..default()
+                },
+            ))
+            .with_children(|parent| {
+                parent
+                    .spawn(SpriteBundle {
+                        sprite: Sprite {
+                            color: Color::ANTIQUE_WHITE,
+                            custom_size: Some(board_size),
+                            ..default()
+                        },
+                        transform: Transform::from_xyz(
+                            board_size.x / 2f32,
+                            board_size.y / 2f32,
+                            0f32,
+                        ),
+                        ..default()
+                    })
+                    .insert(Name::new("Background"));
+
+                for (y, line) in tile_map.iter().enumerate() {
+                    for (x, _) in line.iter().enumerate() {
+                        parent
+                            .spawn(SpriteBundle {
+                                sprite: Sprite {
+                                    color: Color::DARK_GRAY,
+                                    custom_size: Some(Vec2::splat(
+                                        tile_size - options.tile_padding,
+                                    )),
+                                    ..default()
+                                },
+                                transform: Transform::from_xyz(
+                                    (x as f32 * tile_size) + (tile_size / 2f32),
+                                    (y as f32 * tile_size) + (tile_size / 2f32),
+                                    1f32,
+                                ),
+                                ..default()
+                            })
+                            .insert(Name::new(format!("Tile: ({}, {})", x, y)))
+                            .insert(Coordinates {
+                                x: x as u16,
+                                y: y as u16,
+                            });
+                    }
+                }
+            });
+    }
+
+    fn adaptive_tile_size(
+        window: &Window,
+        (min, max): (f32, f32),
+        (width, height): (u16, u16),
+    ) -> f32 {
+        let max_width = window.resolution.width() / width as f32;
+        let max_height = window.resolution.height() / height as f32;
+        max_width.min(max_height).clamp(min, max)
     }
 }

--- a/src/resources/board_options.rs
+++ b/src/resources/board_options.rs
@@ -1,0 +1,52 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub enum TileSize {
+    Fixed(f32),
+    WindowAdaptive { min: f32, max: f32 },
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub enum BoardPosition {
+    Centered { offset: Vec3 },
+    CustomPosition(Vec3),
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Resource)]
+pub struct BoardOptions {
+    pub map_size: (u16, u16),
+    pub mine_count: u16,
+    pub position: BoardPosition,
+    pub tile_size: TileSize,
+    pub tile_padding: f32,
+    pub safe_start_enabled: bool,
+}
+
+impl Default for TileSize {
+    fn default() -> Self {
+        Self::WindowAdaptive {
+            min: 10f32,
+            max: 50f32,
+        }
+    }
+}
+
+impl Default for BoardPosition {
+    fn default() -> Self {
+        Self::Centered { offset: Vec3::ZERO }
+    }
+}
+
+impl Default for BoardOptions {
+    fn default() -> Self {
+        Self {
+            map_size: (15, 15),
+            mine_count: 30,
+            position: Default::default(),
+            tile_size: Default::default(),
+            tile_padding: 0f32,
+            safe_start_enabled: false,
+        }
+    }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -1,4 +1,8 @@
+pub use board_options::BoardOptions;
+pub use board_options::BoardPosition;
+pub use board_options::TileSize;
 pub use tile_map::TileMap;
 
+mod board_options;
 mod tile;
 mod tile_map;

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,7 @@
-mod camera;
-
 pub use camera::setup_2d_camera;
+pub use vsync::toggle_vsync;
+pub use window_visibility::make_window_visible_after_startup;
+
+mod camera;
+mod vsync;
+mod window_visibility;

--- a/src/systems/vsync.rs
+++ b/src/systems/vsync.rs
@@ -1,0 +1,21 @@
+use bevy::prelude::*;
+use bevy::window::PresentMode;
+
+/// This system toggles the vsync mode when pressing the button V.
+/// You'll see FPS increase displayed in the console (if debug feature is enabled)
+pub fn toggle_vsync(input: Res<Input<KeyCode>>, mut windows: Query<&mut Window>) {
+    if input.just_pressed(KeyCode::V) {
+        let mut window = windows.single_mut();
+
+        window.present_mode = if matches!(window.present_mode, PresentMode::AutoVsync) {
+            PresentMode::AutoNoVsync
+        } else {
+            PresentMode::AutoVsync
+        };
+
+        info!(
+            "[V] key pressed. Changing VSync mode to: {:?}",
+            window.present_mode
+        );
+    }
+}

--- a/src/systems/window_visibility.rs
+++ b/src/systems/window_visibility.rs
@@ -1,0 +1,17 @@
+use bevy::core::FrameCount;
+use bevy::prelude::*;
+
+const FRAME_COUNT_TO_MAKE_WINDOW_VISIBLE: u32 = 3;
+
+pub fn make_window_visible_after_startup(mut window: Query<&mut Window>, frames: Res<FrameCount>) {
+    if frames.0 == FRAME_COUNT_TO_MAKE_WINDOW_VISIBLE {
+        // At this point the gpu is ready to show the app so we can make the window visible.
+        // Alternatively, you could toggle the visibility in Startup.
+        // It will work, but it will have one white frame before it starts rendering
+        info!(
+            "Making window visible after {} frames",
+            FRAME_COUNT_TO_MAKE_WINDOW_VISIBLE
+        );
+        window.single_mut().visible = true;
+    }
+}


### PR DESCRIPTION
- updated board creation in accordance with new `BoardOptions` configuration, controlling aspects like board size, position, mine count, tile sizes, and padding
- added new feature to the game where the window now becomes visible after the GPU is ready, avoiding a white frame flash at startup
- VSync can now be toggled by pressing `V` key