### PR TITLE
feat: uncovering tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ TODO: Fill this list
 
 * Rust Minesweeper clone adapted from tutorial [here](https://dev.to/qongzi/series/16975) to Bevy 0.12
 * Assets and icons created using `Aseprite` (https://github.com/aseprite/aseprite). To build from source see this guide: https://gist.github.com/luciopaiva/6a1f870f932a5f54011cc869c4d558a8
+* Played a little bit with [JetBrains AI assistant](https://www.jetbrains.com/ai/) for documentation, code generation and commit messages completion
 
 ## Learning resources
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
-# Rust Minesweeper <img src="icons\Bomb-Icon-256.png" height="32" width="32"/>
+# Rust Minesweeper
 
 Minesweeper in Rust and Bevy
 
-Based on the Minesweeper tutorial series [here](https://dev.to/qongzi/series/16975) and adapted to the latest Bevy version (`0.12`)
+Based on the Minesweeper tutorial series [here](https://dev.to/qongzi/series/16975) and adapted to the latest Bevy
+version (`0.12`)
+
+<!-- TOC -->
+* [Rust Minesweeper](#rust-minesweeper)
+  * [Features](#features)
+  * [Learning resources](#learning-resources)
+  * [Running the debug build](#running-the-debug-build)
+  * [Building](#building)
+    * [Using `RUSTFLAGS` env variable](#using-rustflags-env-variable)
+  * [Gallery](#gallery)
+  * [License](#license)
+  * [Contributions](#contributions)
+<!-- TOC -->
 
 ## Features
 
 TODO: Fill this list
 
 * Rust Minesweeper clone adapted from tutorial [here](https://dev.to/qongzi/series/16975) to Bevy 0.12
-* Assets and icons created using `Aseprite` (https://github.com/aseprite/aseprite). To build from source see this guide: https://gist.github.com/luciopaiva/6a1f870f932a5f54011cc869c4d558a8
-* Played a little bit with [JetBrains AI assistant](https://www.jetbrains.com/ai/) for documentation, code generation and commit messages completion
+* Assets and icons created using `Aseprite` (https://github.com/aseprite/aseprite). To build from source see this
+  guide: https://gist.github.com/luciopaiva/6a1f870f932a5f54011cc869c4d558a8
+* Additional debug console logging and `bevy-inspector-egui` can be enabled using the `debug` feature
+  (see: [Running the debug build section](#running-the-debug-build))
+* Played a little bit with [JetBrains AI assistant](https://www.jetbrains.com/ai/) for documentation, code generation
+  and commit messages completion
 
 ## Learning resources
 
@@ -23,13 +40,15 @@ TODO: Fill this list
 ## Running the debug build
 
 You can run the debug build using `debug` feature flag with:
+
 ```
 git clone https://github.com/jpiechowka/rust-minesweeper.git
 cd rust-minesweeper
 cargo run --package rust-minesweeper --bin rust-minesweeper --features debug
 ```
 
-Logging can be configured using the `RUST_LOG` environment variable (https://bevy-cheatbook.github.io/fundamentals/log.html#environment-variable)
+Logging can be configured using the `RUST_LOG` environment
+variable (https://bevy-cheatbook.github.io/fundamentals/log.html#environment-variable)
 
 ## Building
 
@@ -41,12 +60,12 @@ cd rust-minesweeper
 cargo build --release
 ```
 
-### Using RUSTFLAGS env variable
+### Using `RUSTFLAGS` env variable
 
 If you do not care that much about the compatibility of your binary on older (or other types of) processors, you can
 tell the compiler to generate the newest (and potentially fastest) instructions specific to a certain CPU architecture
-by using `RUSTFLAGS`environment
-variable (https://nnethercote.github.io/perf-book/build-configuration.html#cpu-specific-instructions)
+by using `RUSTFLAGS`
+environment (https://nnethercote.github.io/perf-book/build-configuration.html#cpu-specific-instructions)
 
 ```
 RUSTFLAGS="-C target-cpu=native" cargo build --release
@@ -68,7 +87,7 @@ TODO: Provide some pictures or video of the final game
 
 ## License
 
-Rust ray tracer is free, open source and permissively licensed! Except where noted (below and/or in individual files),
+Rust Minesweeper is free, open source and permissively licensed! Except where noted (below and/or in individual files),
 all code in this repository is dual-licensed under either:
 
 * MIT License (`LICENSE-MIT` file or http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Based on the Minesweeper tutorial series [here](https://dev.to/qongzi/series/169
 
 TODO: Fill this list
 
+* Rust Minesweeper clone adapted from tutorial [here](https://dev.to/qongzi/series/16975) to Bevy 0.12
 * Assets and icons created using `Aseprite` (https://github.com/aseprite/aseprite). To build from source see this guide: https://gist.github.com/luciopaiva/6a1f870f932a5f54011cc869c4d558a8
 
 ## Learning resources

--- a/src/plugins/board_plugin/board.rs
+++ b/src/plugins/board_plugin/board.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 use bevy::window::PrimaryWindow;
 
 use crate::components::{Coordinates, Mine, MineNeighbor};
@@ -61,6 +62,9 @@ impl BoardPlugin {
             BoardPosition::CustomPosition(pos) => pos,
         };
 
+        let mut covered_tiles =
+            HashMap::with_capacity((tile_map.width() * tile_map.height()).into());
+
         info!("Spawning board");
         commands
             .spawn((
@@ -93,6 +97,8 @@ impl BoardPlugin {
                     tile_size,
                     options.tile_padding,
                     Color::DARK_GRAY,
+                    Color::DARK_GRAY,
+                    &mut covered_tiles,
                     mine_sprite,
                     font,
                 );
@@ -105,6 +111,7 @@ impl BoardPlugin {
                 size: board_size,
             },
             tile_size,
+            covered_tiles,
         });
     }
 
@@ -114,11 +121,18 @@ impl BoardPlugin {
         tile_size: f32,
         tile_padding: f32,
         background_color: Color,
+        covered_tile_color: Color,
+        covered_tiles: &mut HashMap<Coordinates, Entity>,
         mine_sprite: Handle<Image>,
         font: Handle<Font>,
     ) {
         for (y, line) in tile_map.iter().enumerate() {
             for (x, tile) in line.iter().enumerate() {
+                let coordinates = Coordinates {
+                    x: x as u16,
+                    y: y as u16,
+                };
+
                 let mut commands = parent.spawn(SpriteBundle {
                     sprite: Sprite {
                         color: background_color,
@@ -135,10 +149,23 @@ impl BoardPlugin {
 
                 commands
                     .insert(Name::new(format!("Tile ({}, {})", x, y)))
-                    .insert(Coordinates {
-                        x: x as u16,
-                        y: y as u16,
-                    });
+                    .insert(coordinates);
+
+                commands.with_children(|parent| {
+                    let entity = parent
+                        .spawn(SpriteBundle {
+                            sprite: Sprite {
+                                custom_size: Some(Vec2::splat(tile_size - tile_padding)),
+                                color: covered_tile_color,
+                                ..default()
+                            },
+                            transform: Transform::from_xyz(0f32, 0f32, 2f32),
+                            ..default()
+                        })
+                        .insert(Name::new("Tile Cover"))
+                        .id();
+                    covered_tiles.insert(coordinates, entity);
+                });
 
                 match tile {
                     Tile::Mine => {

--- a/src/plugins/board_plugin/board_plugin.rs
+++ b/src/plugins/board_plugin/board_plugin.rs
@@ -3,9 +3,9 @@ use bevy::utils::HashMap;
 use bevy::window::PrimaryWindow;
 
 use crate::components::{Coordinates, Mine, MineNeighbor};
-use crate::plugins::Bounds2;
+use crate::plugins::{Bounds2, TileTriggerEvent};
 use crate::resources::{Board, BoardOptions, BoardPosition, Tile, TileMap, TileSize};
-use crate::systems::handle_mouse_input;
+use crate::systems::{handle_mouse_input, trigger_event_handler, uncover_tiles};
 
 pub struct BoardPlugin;
 
@@ -13,6 +13,9 @@ impl Plugin for BoardPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, Self::create_board);
         app.add_systems(Update, handle_mouse_input);
+        app.add_systems(Update, trigger_event_handler);
+        app.add_systems(Update, uncover_tiles);
+        app.add_event::<TileTriggerEvent>();
         info!("Loaded Board Plugin");
     }
 }
@@ -97,7 +100,7 @@ impl BoardPlugin {
                     tile_size,
                     options.tile_padding,
                     Color::DARK_GRAY,
-                    Color::DARK_GRAY,
+                    Color::GRAY,
                     &mut covered_tiles,
                     mine_sprite,
                     font,

--- a/src/plugins/board_plugin/events.rs
+++ b/src/plugins/board_plugin/events.rs
@@ -1,0 +1,8 @@
+use bevy::prelude::*;
+
+use crate::components::Coordinates;
+
+#[derive(Debug, Clone, Copy, Event)]
+pub struct TileTriggerEvent {
+    pub coordinates: Coordinates,
+}

--- a/src/plugins/board_plugin/mod.rs
+++ b/src/plugins/board_plugin/mod.rs
@@ -1,5 +1,7 @@
 pub use board::BoardPlugin;
 pub use bounds::Bounds2;
+pub use events::TileTriggerEvent;
 
 mod board;
 mod bounds;
+mod events;

--- a/src/plugins/board_plugin/mod.rs
+++ b/src/plugins/board_plugin/mod.rs
@@ -1,7 +1,7 @@
-pub use board::BoardPlugin;
+pub use board_plugin::BoardPlugin;
 pub use bounds::Bounds2;
 pub use events::TileTriggerEvent;
 
-mod board;
+mod board_plugin;
 mod bounds;
 mod events;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,5 @@
 pub use board_plugin::BoardPlugin;
 pub use board_plugin::Bounds2;
+pub use board_plugin::TileTriggerEvent;
 
 mod board_plugin;

--- a/src/resources/board.rs
+++ b/src/resources/board.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 
 use crate::components::Coordinates;
 use crate::plugins::Bounds2;
@@ -9,6 +10,7 @@ pub struct Board {
     pub tile_map: TileMap,
     pub bounds: Bounds2,
     pub tile_size: f32,
+    pub covered_tiles: HashMap<Coordinates, Entity>,
 }
 
 impl Board {
@@ -26,5 +28,21 @@ impl Board {
             // https://bevyengine.org/learn/migration-guides/0.10-0.11/#consistent-screen-space-coordinates
             y: self.tile_map.height() - 1 - (coordinates.y / self.tile_size) as u16,
         })
+    }
+
+    pub fn tile_to_uncover(&self, coordinates: &Coordinates) -> Option<&Entity> {
+        self.covered_tiles.get(coordinates)
+    }
+
+    pub fn try_uncover_tile(&mut self, coordinates: &Coordinates) -> Option<Entity> {
+        self.covered_tiles.remove(coordinates)
+    }
+
+    pub fn adjacent_covered_tiles(&self, coordinates: Coordinates) -> Vec<Entity> {
+        self.tile_map
+            .safe_square_at(coordinates)
+            .filter_map(|coord| self.covered_tiles.get(&coord))
+            .copied()
+            .collect()
     }
 }

--- a/src/systems/input_handler.rs
+++ b/src/systems/input_handler.rs
@@ -3,12 +3,14 @@ use bevy::input::ButtonState;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
+use crate::plugins::TileTriggerEvent;
 use crate::resources::Board;
 
 pub fn handle_mouse_input(
     window_query: Query<&Window, With<PrimaryWindow>>,
     board: Res<Board>,
     mut button_event_reader: EventReader<MouseButtonInput>,
+    mut tile_trigger_event_writer: EventWriter<TileTriggerEvent>,
 ) {
     let window = window_query.single();
 
@@ -22,6 +24,9 @@ pub fn handle_mouse_input(
                                 "LMB clicked, trying to uncover tile on {}",
                                 tile_coordinates
                             );
+                            tile_trigger_event_writer.send(TileTriggerEvent {
+                                coordinates: tile_coordinates,
+                            });
                         }
                         MouseButton::Right => {
                             info!("RMB clicked, trying to mark tile on {}", tile_coordinates);

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,9 +1,12 @@
 pub use camera::setup_2d_camera;
 pub use input_handler::handle_mouse_input;
+pub use uncover::trigger_event_handler;
+pub use uncover::uncover_tiles;
 pub use vsync::toggle_vsync;
 pub use window_visibility::make_window_visible_after_startup;
 
 mod camera;
 mod input_handler;
+mod uncover;
 mod vsync;
 mod window_visibility;

--- a/src/systems/uncover.rs
+++ b/src/systems/uncover.rs
@@ -1,0 +1,51 @@
+use bevy::prelude::*;
+
+use crate::components::{Coordinates, Mine, MineNeighbor, Uncover};
+use crate::plugins::TileTriggerEvent;
+use crate::resources::Board;
+
+pub fn trigger_event_handler(
+    mut commands: Commands,
+    board: Res<Board>,
+    mut tile_trigger_event_reader: EventReader<TileTriggerEvent>,
+) {
+    // adopted
+    for trigger_event in tile_trigger_event_reader.read() {
+        if let Some(entity) = board.tile_to_uncover(&trigger_event.coordinates) {
+            commands.entity(*entity).insert(Uncover);
+        }
+    }
+}
+
+pub fn uncover_tiles(
+    mut commands: Commands,
+    mut board: ResMut<Board>,
+    children: Query<(Entity, &Parent), With<Uncover>>,
+    parents: Query<(&Coordinates, Option<&Mine>, Option<&MineNeighbor>)>,
+) {
+    for (entity, parent) in children.iter() {
+        commands.entity(entity).despawn_recursive();
+
+        let (coordinates, bomb, bomb_counter) = match parents.get(parent.get()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("{}", e);
+                continue;
+            }
+        };
+
+        match board.try_uncover_tile(coordinates) {
+            None => info!("Tried to uncover an already uncovered tile"),
+            Some(e) => info!("Uncovered tile {} (entity: {:?})", coordinates, e),
+        }
+
+        if bomb.is_some() {
+            info!("Boom!");
+            // TODO: Add explosion event
+        } else if bomb_counter.is_none() {
+            for entity in board.adjacent_covered_tiles(*coordinates) {
+                commands.entity(entity).insert(Uncover);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes:

* A new `covered_tiles` field has been added to the 'Board' struct allowing to map coordinates to uncovered tile entities. Relevant methods to manipulate and retrieve these tiles have also been included. Changes include modifications in the `board_plugin` for the spawning logic of the covered tiles.
* Added a new event called `TileTriggerEvent` to handle tile interaction upon left mouse button (LMB) clicks. The `TileTriggerEvent` is being passed with the tile coordinates which allows further interaction with the tile.
* The `board` module has been renamed to `board_plugin`. A new `uncover` system is added to handle triggering and processing of uncovering tiles. This system interacts with `BoardPlugin` to add functionality for uncovering tiles upon receiving a `TileTriggerEvent`.

![image](https://github.com/jpiechowka/rust-minesweeper/assets/9040085/57b5ea25-b7c6-4de6-9c2c-115878192315)
