### PR TITLE
feat: increase starting `mine_count`, modify board color, and implement `safe_start`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,9 @@ fn main() {
 
     app.insert_resource(BoardOptions {
         map_size: (20, 20),
-        mine_count: 40,
+        mine_count: 60,
         tile_padding: 3.0,
+        safe_start_enabled: true,
         ..default()
     });
 


### PR DESCRIPTION
In the `BoardOptions`, the `mine_count` was increased from 40 to 60, and the `safe_start_enabled` option was added and set to true. The `color` in the board `SpriteBundle` was changed from `ANTIQUE_WHITE` to `BLACK`. New logic was introduced to handle the `safe_start` function where the first uncovered tile will always be safe.

![image](https://github.com/jpiechowka/rust-minesweeper/assets/9040085/0d38280e-7d21-47c5-9d7e-827a75d438c2)
