### PR TITLE
feat: add more key mappings and game state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ version (`0.12`)
 
 <!-- TOC -->
 * [Rust Minesweeper](#rust-minesweeper)
+  * [Key mappings](#key-mappings)
   * [Features](#features)
   * [Learning resources](#learning-resources)
   * [Running the debug build](#running-the-debug-build)
@@ -17,9 +18,13 @@ version (`0.12`)
   * [Contributions](#contributions)
 <!-- TOC -->
 
-## Features
+## Key mappings
 
-TODO: Fill this list
+* `C`: clear board
+* `V`: toggle V-Sync (on / off)
+* `R`: (re)generate new board (requires clearing the board first)
+
+## Features
 
 * Rust Minesweeper clone adapted from tutorial [here](https://dev.to/qongzi/series/16975) to Bevy 0.12
 * Assets and icons created using `Aseprite` (https://github.com/aseprite/aseprite). To build from source see this

--- a/src/resources/board.rs
+++ b/src/resources/board.rs
@@ -11,6 +11,7 @@ pub struct Board {
     pub bounds: Bounds2,
     pub tile_size: f32,
     pub covered_tiles: HashMap<Coordinates, Entity>,
+    pub entity: Entity,
 }
 
 impl Board {


### PR DESCRIPTION
Game states (InGame, Out) have been introduced with key mappings (Clear board and Regenerate board). Main functionality updates involve responding to the key presses and changing game state accordingly. The README has also been updated with a new section listing key mappings.

Clearing the board:

![image](https://github.com/jpiechowka/rust-minesweeper/assets/9040085/9f11f30c-dae0-45e8-b9dd-1fde705ddbd4)

Regenerated board:

![image](https://github.com/jpiechowka/rust-minesweeper/assets/9040085/2ba6023d-fd6e-4900-8323-f0edd96c259d)
